### PR TITLE
Change to move tests about `match_type` in the reverse geocode case.

### DIFF
--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -516,40 +516,25 @@ class IGNFrance(Geocoder):   # pylint: disable=W0223
         if is_freeform == 'true':
             location = place.get('freeformaddress')
         else:
-            # When classic geocoding
-            if place.get('match_type'):
+            # For parcelle
+            if place.get('numero'):
+                location = place.get('street')
+            else:
+                # When classic geocoding
+                # or when reverse geocoding
                 location = "%s %s" % (
                     place.get('postal_code', ''),
                     place.get('commune', ''),
                 )
-                if place.get('match_type') in ['Street number',
-                                               'Street enhanced']:
-                    location = "%s %s, %s" % (
-                        place.get('building', ''),
+                if place.get('street'):
+                    location = "%s, %s" % (
                         place.get('street', ''),
                         location,
                     )
-                elif place.get('match_type') == 'Street':
-                    location = "%s, %s" % (place.get('street', ''), location)
-            else:
-                # For parcelle
-                if place.get('numero'):
-                    location = place.get('street')
-                else:
-                    # When reverse geocoding
+                if place.get('building'):
                     location = "%s %s" % (
-                        place.get('postal_code', ''),
-                        place.get('commune', ''),
+                        place.get('building', ''),
+                        location,
                     )
-                    if place.get('street'):
-                        location = "%s, %s" % (
-                            place.get('street', ''),
-                            location,
-                        )
-                    if place.get('building'):
-                        location = "%s %s" % (
-                            place.get('building', ''),
-                            location,
-                        )
 
         return Location(location, (place.get('lat'), place.get('lng')), place)

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -77,6 +77,20 @@ class IGNFranceTestCase(GeocoderTestBase):
             {"latitude": 47.222482, "longitude": -1.556303},
         )
 
+    def test_geocode_with_address(self):
+        """
+        IGNFrance.geocode Adress
+        """
+        self.geocode_run(
+            {"query": "Camp des Landes, 41200 VILLEFRANCHE-SUR-CHER",
+             "query_type": "StreetAddress",
+             "exactly_one": True},
+            {"latitude": 47.293048,
+             "longitude": 1.718985,
+             "address": "le camp des landes, 41200 Villefranche-sur-Cher"
+            },
+        )
+
     def test_geocode_freeform(self):
         """
         IGNFrance.geocode with freeform and StreetAddress

--- a/test/geocoders/util.py
+++ b/test/geocoders/util.py
@@ -99,6 +99,7 @@ class GeocoderTestBase(unittest.TestCase): # pylint: disable=R0904
             raw=EMPTY,
             latitude=EMPTY,
             longitude=EMPTY,
+            address=EMPTY
         ):
         """
         Verifies that a a result matches the kwargs given.
@@ -114,4 +115,8 @@ class GeocoderTestBase(unittest.TestCase): # pylint: disable=R0904
         if longitude != EMPTY:
             self.assertAlmostEqual(
                 item.longitude, longitude, delta=self.delta
+            )
+        if address != EMPTY:
+            self.assertEqual(
+                item.address, address
             )


### PR DESCRIPTION
The case match_type in 'Street enhanced' where no building number is not working the expected way so keeping a special use case for this purpose is not useful.
We added a new test and made a change in test/geocoders/util.py class to also test address key and not only raw, longitude and latitude.